### PR TITLE
Change application name template to "Mythic"

### DIFF
--- a/dlls/winemac.drv/cocoa_app.h
+++ b/dlls/winemac.drv/cocoa_app.h
@@ -67,8 +67,8 @@ enum {
 };
 
 /* Whisky hack #9 */
-#define kAppNameText @"%@ (Whi" \
-                     @"sky)"
+#define kAppNameText @"%@ (Myt" \
+                     @"hic)"
 
 
 @class WineEventQueue;

--- a/dlls/winemac.drv/cocoa_app.m
+++ b/dlls/winemac.drv/cocoa_app.m
@@ -394,7 +394,6 @@ static NSString* WineLocalizedString(unsigned int stringID)
             bool success = [self setProcessName:appName];
             if (!success)
                 NSLog(@"Failed to set process name to %@", appName);
-            [appName release];
         }
     }
 


### PR DESCRIPTION
The original text in the application name template would result in `example.exe (Whisky)`. As this is Mythic's Engine, this PR changes the template to Mythic instead of Whisky. e.g. `example.exe (Mythic)`.